### PR TITLE
Update v usage in the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ jobs:
     - name: Set up V version 0.1.24
       uses: nocturlab/setup-vlang-action@v1
       with:
-        v-version: 0.1.24
+        v-version: latest
       id: v
     - name: Build repository app
-      run: v build .
+      run: v .
     - name: Run V tests
       run: v test .
 ```


### PR DESCRIPTION
In v you now can't use `v build .`
You must use `v .` to build your app.
So I change it in the readme.md